### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,5 +369,5 @@ https://docs.qq.com/doc/DV1hFUGpMV1l3eVdV)
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=datawhalechina/competition-baseline&type=Date)](https://star-history.com/#datawhalechina/competition-baseline&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=datawhalechina/competition-baseline&type=Date)](https://star-history.dera.page/#datawhalechina/competition-baseline&Date)
 


### PR DESCRIPTION
The star history chart in the README is currently broken because it relies on GitHub's restricted stargazer API. This change points it to a working source so visitors can view the project's star history again. No other changes are included.